### PR TITLE
change gpt-4o deployment from standard to global standard

### DIFF
--- a/infra/ai.yaml
+++ b/infra/ai.yaml
@@ -15,7 +15,7 @@ deployments:
       name: gpt-4o
       version: "2024-05-13"
     sku:
-      name: Standard
+      name: GlobalStandard
       capacity: 20
   - name: text-embedding-ada-002
     model:


### PR DESCRIPTION
Right now there seems to be only eastus supporting both gpt-4o standard deployments and semantic reranker for AI search. I suggest to use globalstandard as default for gpt-4o to 

- have more regions available during trainings
- showcase how to use different deployment types