### PR TITLE
Update ai.yaml - gpt-35-turbo version update

### DIFF
--- a/infra/ai.yaml
+++ b/infra/ai.yaml
@@ -5,7 +5,7 @@ deployments:
     model:
       format: OpenAI
       name: gpt-35-turbo
-      version: "0613"
+      version: "0125"
     sku:
       name: Standard
       capacity: 20


### PR DESCRIPTION
gpt-35 turbo version 0613 has been deprecated. Updating it to **0125** otherwise deployment will fail. See error below.

```
ERROR: deployment failed: error deploying infrastructure: deploying to subscription:

Deployment Error Details:
InvalidTemplateDeployment: The template deployment 'cognitiveServices' is not valid according to the validation procedure. The tracking id is 'xxxxxx'. See inner errors for details. ServiceModelDeprecated: The model 'Publisher: , Format: OpenAI, Name: gpt-35-turbo, Version: 0613, Source: , SourceAccount: ' has been deprecated since 02/13/2025 00:00:00.

TraceID: xxxxxxxxx
Failed to provision the Azure environment.
```